### PR TITLE
Fix logo missing on non-home pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,7 +27,7 @@
 <header class="site-header">
   <div class="header-inner container">
     <a class="brand" href="index.html" aria-label="SpendLess! Home">
-      <img class="brand-logo" src="assets/brand/piggy.svg" alt="SpendLess! piggy bank logo"> <span class="brand-title">SpendLess!</span>
+      <img class="brand-logo" src="assets/brand/piggy.png" alt="SpendLess! piggy bank logo"> <span class="brand-title">SpendLess!</span>
     </a>
     <nav class="primary" aria-label="Primary">
       <a href="index.html">Featured</a>

--- a/article.html
+++ b/article.html
@@ -27,7 +27,7 @@
 <header class="site-header">
   <div class="header-inner container">
     <a class="brand" href="index.html" aria-label="SpendLess! Home">
-      <img class="brand-logo" src="assets/brand/piggy.svg" alt="SpendLess! piggy bank logo"> <span class="brand-title">SpendLess!</span>
+      <img class="brand-logo" src="assets/brand/piggy.png" alt="SpendLess! piggy bank logo"> <span class="brand-title">SpendLess!</span>
     </a>
     <nav class="primary" aria-label="Primary">
       <a href="index.html">Featured</a>

--- a/privacy.html
+++ b/privacy.html
@@ -27,7 +27,7 @@
 <header class="site-header">
   <div class="header-inner container">
     <a class="brand" href="index.html" aria-label="SpendLess! Home">
-      <img class="brand-logo" src="assets/brand/piggy.svg" alt="SpendLess! piggy bank logo"> <span class="brand-title">SpendLess!</span>
+      <img class="brand-logo" src="assets/brand/piggy.png" alt="SpendLess! piggy bank logo"> <span class="brand-title">SpendLess!</span>
     </a>
     <nav class="primary" aria-label="Primary">
       <a href="index.html">Featured</a>


### PR DESCRIPTION
## Summary
- Use existing `piggy.png` logo instead of missing `piggy.svg` so branding displays across the site.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b09c9923d88326852169d29112e14a