### PR TITLE
Fix favicon paths and mobile menu overlay

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,11 +15,11 @@
   <meta property="og:title" content="SpendLess! — Fresh Deals & Promo Codes">
   <meta property="og:description" content="Mobile-first deals: coupons, promo codes, and discounts with reveal-to-copy and one-click to shop.">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="site.webmanifest">
 
 </head>
 <body>
@@ -40,23 +40,23 @@
     </nav>
     <button class="burger js-open" aria-label="Open menu"><span class="burger-lines"></span></button>
   </div>
-  <div class="mobile-nav" aria-hidden="true" role="dialog" aria-label="Mobile menu">
-    <div class="sheet">
-      <button class="close js-close" aria-label="Close menu">✕</button>
-      <h3>Browse deals</h3>
-      <a href="index.html">Featured</a>
-      <a href="index.html?cat=Travel">Travel</a>
-      <a href="index.html?cat=Fashion">Fashion</a>
-      <a href="index.html?cat=Marketplace">Marketplace</a>
-      <a href="index.html?cat=Automotive">Automotive</a>
-      <a href="index.html?cat=Health">Health</a>
-      <a href="index.html?cat=Tech">Tech</a>
-      <hr>
-      <a href="about.html">About</a>
-      <a href="privacy.html">Privacy</a>
-    </div>
-  </div>
 </header>
+<div class="mobile-nav" aria-hidden="true" role="dialog" aria-label="Mobile menu">
+  <div class="sheet">
+    <button class="close js-close" aria-label="Close menu">✕</button>
+    <h3>Browse deals</h3>
+    <a href="index.html">Featured</a>
+    <a href="index.html?cat=Travel">Travel</a>
+    <a href="index.html?cat=Fashion">Fashion</a>
+    <a href="index.html?cat=Marketplace">Marketplace</a>
+    <a href="index.html?cat=Automotive">Automotive</a>
+    <a href="index.html?cat=Health">Health</a>
+    <a href="index.html?cat=Tech">Tech</a>
+    <hr>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+  </div>
+</div>
 
   <main class="container">
     <h1>About SpendLess!</h1>
@@ -99,6 +99,6 @@
   </div>
   <div class="smallprint">&copy; 2025 SpendLess!. All rights reserved. Affiliate links may earn us a commission.</div>
 </footer>
-
+<script src="js/nav.js" defer></script>
 </body>
 </html>

--- a/article.html
+++ b/article.html
@@ -15,11 +15,11 @@
   <meta property="og:title" content="SpendLess! — Fresh Deals & Promo Codes">
   <meta property="og:description" content="Mobile-first deals: coupons, promo codes, and discounts with reveal-to-copy and one-click to shop.">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="site.webmanifest">
 
 </head>
 <body>
@@ -40,23 +40,23 @@
     </nav>
     <button class="burger js-open" aria-label="Open menu"><span class="burger-lines"></span></button>
   </div>
-  <div class="mobile-nav" aria-hidden="true" role="dialog" aria-label="Mobile menu">
-    <div class="sheet">
-      <button class="close js-close" aria-label="Close menu">✕</button>
-      <h3>Browse deals</h3>
-      <a href="index.html">Featured</a>
-      <a href="index.html?cat=Travel">Travel</a>
-      <a href="index.html?cat=Fashion">Fashion</a>
-      <a href="index.html?cat=Marketplace">Marketplace</a>
-      <a href="index.html?cat=Automotive">Automotive</a>
-      <a href="index.html?cat=Health">Health</a>
-      <a href="index.html?cat=Tech">Tech</a>
-      <hr>
-      <a href="about.html">About</a>
-      <a href="privacy.html">Privacy</a>
-    </div>
-  </div>
 </header>
+<div class="mobile-nav" aria-hidden="true" role="dialog" aria-label="Mobile menu">
+  <div class="sheet">
+    <button class="close js-close" aria-label="Close menu">✕</button>
+    <h3>Browse deals</h3>
+    <a href="index.html">Featured</a>
+    <a href="index.html?cat=Travel">Travel</a>
+    <a href="index.html?cat=Fashion">Fashion</a>
+    <a href="index.html?cat=Marketplace">Marketplace</a>
+    <a href="index.html?cat=Automotive">Automotive</a>
+    <a href="index.html?cat=Health">Health</a>
+    <a href="index.html?cat=Tech">Tech</a>
+    <hr>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+  </div>
+</div>
 
   <main class="container">
     <article>
@@ -114,6 +114,7 @@
 </footer>
 
   <script src="js/marked.min.js"></script>
+  <script src="js/nav.js" defer></script>
   <script src="js/article.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,11 +15,11 @@
   <meta property="og:title" content="SpendLess! — Fresh Deals & Promo Codes">
   <meta property="og:description" content="Mobile-first deals: coupons, promo codes, and discounts with reveal-to-copy and one-click to shop.">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="site.webmanifest">
 
 </head>
 <body>
@@ -41,23 +41,23 @@
     </nav>
     <button class="burger js-open" aria-label="Open menu"><span class="burger-lines"></span></button>
   </div>
-  <div class="mobile-nav" aria-hidden="true" role="dialog" aria-label="Mobile menu">
-    <div class="sheet">
-      <button class="close js-close" aria-label="Close menu">✕</button>
-      <h3>Browse deals</h3>
-      <a href="index.html">Featured</a>
-      <a href="index.html?cat=Travel">Travel</a>
-      <a href="index.html?cat=Fashion">Fashion</a>
-      <a href="index.html?cat=Marketplace">Marketplace</a>
-      <a href="index.html?cat=Automotive">Automotive</a>
-      <a href="index.html?cat=Health">Health</a>
-      <a href="index.html?cat=Tech">Tech</a>
-      <hr>
-      <a href="about.html">About</a>
-      <a href="privacy.html">Privacy</a>
-    </div>
-  </div>
 </header>
+<div class="mobile-nav" aria-hidden="true" role="dialog" aria-label="Mobile menu">
+  <div class="sheet">
+    <button class="close js-close" aria-label="Close menu">✕</button>
+    <h3>Browse deals</h3>
+    <a href="index.html">Featured</a>
+    <a href="index.html?cat=Travel">Travel</a>
+    <a href="index.html?cat=Fashion">Fashion</a>
+    <a href="index.html?cat=Marketplace">Marketplace</a>
+    <a href="index.html?cat=Automotive">Automotive</a>
+    <a href="index.html?cat=Health">Health</a>
+    <a href="index.html?cat=Tech">Tech</a>
+    <hr>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+  </div>
+</div>
 
   <main class="container">
     <section class="hero">
@@ -106,6 +106,7 @@
   <div class="smallprint">&copy; 2025 SpendLess!. All rights reserved. Affiliate links may earn us a commission.</div>
 </footer>
 
+  <script src="js/nav.js" defer></script>
   <script src="js/home.js" defer></script>
 </body>
 </html>

--- a/js/article.js
+++ b/js/article.js
@@ -63,28 +63,7 @@ function renderArticle(article){
   });
 }
 
-function setupHeader(){
-  const openBtn = document.querySelector('.js-open');
-  const sheetWrap = document.querySelector('.mobile-nav');
-  const closeBtn = document.querySelector('.js-close');
-  if (!openBtn || !sheetWrap) return;
-  openBtn.addEventListener('click', ()=>{
-    openBtn.classList.add('burger-open');
-    sheetWrap.classList.add('is-open');
-    sheetWrap.setAttribute('aria-hidden','false');
-  });
-  const close = ()=>{
-    openBtn.classList.remove('burger-open');
-    sheetWrap.classList.remove('is-open');
-    sheetWrap.setAttribute('aria-hidden','true');
-  };
-  closeBtn?.addEventListener('click', close);
-  sheetWrap.addEventListener('click', (e)=>{ if(e.target === sheetWrap) close(); });
-  document.addEventListener('keydown', (e)=>{ if(e.key === 'Escape') close(); });
-}
-
 async function init(){
-  setupHeader();
   const slug = getSlug();
   const articles = await loadArticles();
   const article = articles.find(a => a.slug === slug);

--- a/js/home.js
+++ b/js/home.js
@@ -74,28 +74,7 @@ function getPageFromQuery(){
   return Math.max(1, p);
 }
 
-function setupHeader(){
-  const openBtn = document.querySelector('.js-open');
-  const sheetWrap = document.querySelector('.mobile-nav');
-  const closeBtn = document.querySelector('.js-close');
-  if (!openBtn || !sheetWrap) return;
-  openBtn.addEventListener('click', ()=>{
-    openBtn.classList.add('burger-open');
-    sheetWrap.classList.add('is-open');
-    sheetWrap.setAttribute('aria-hidden','false');
-  });
-  const close = ()=>{
-    openBtn.classList.remove('burger-open');
-    sheetWrap.classList.remove('is-open');
-    sheetWrap.setAttribute('aria-hidden','true');
-  };
-  closeBtn?.addEventListener('click', close);
-  sheetWrap.addEventListener('click', (e)=>{ if(e.target === sheetWrap) close(); });
-  document.addEventListener('keydown', (e)=>{ if(e.key === 'Escape') close(); });
-}
-
 async function init(){
-  setupHeader();
   const data = await API.loadArticles();
   const filtered = filterByCategory(data.articles);
   const page = getPageFromQuery();

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,0 +1,21 @@
+function setupHeader(){
+  const openBtn = document.querySelector('.js-open');
+  const sheetWrap = document.querySelector('.mobile-nav');
+  const closeBtn = document.querySelector('.js-close');
+  if (!openBtn || !sheetWrap) return;
+  openBtn.addEventListener('click', ()=>{
+    openBtn.classList.add('burger-open');
+    sheetWrap.classList.add('is-open');
+    sheetWrap.setAttribute('aria-hidden','false');
+  });
+  const close = ()=>{
+    openBtn.classList.remove('burger-open');
+    sheetWrap.classList.remove('is-open');
+    sheetWrap.setAttribute('aria-hidden','true');
+  };
+  closeBtn?.addEventListener('click', close);
+  sheetWrap.addEventListener('click', (e)=>{ if(e.target === sheetWrap) close(); });
+  document.addEventListener('keydown', (e)=>{ if(e.key === 'Escape') close(); });
+}
+
+document.addEventListener('DOMContentLoaded', setupHeader);

--- a/privacy.html
+++ b/privacy.html
@@ -15,11 +15,11 @@
   <meta property="og:title" content="SpendLess! — Fresh Deals & Promo Codes">
   <meta property="og:description" content="Mobile-first deals: coupons, promo codes, and discounts with reveal-to-copy and one-click to shop.">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="site.webmanifest">
 
 </head>
 <body>
@@ -40,23 +40,23 @@
     </nav>
     <button class="burger js-open" aria-label="Open menu"><span class="burger-lines"></span></button>
   </div>
-  <div class="mobile-nav" aria-hidden="true" role="dialog" aria-label="Mobile menu">
-    <div class="sheet">
-      <button class="close js-close" aria-label="Close menu">✕</button>
-      <h3>Browse deals</h3>
-      <a href="index.html">Featured</a>
-      <a href="index.html?cat=Travel">Travel</a>
-      <a href="index.html?cat=Fashion">Fashion</a>
-      <a href="index.html?cat=Marketplace">Marketplace</a>
-      <a href="index.html?cat=Automotive">Automotive</a>
-      <a href="index.html?cat=Health">Health</a>
-      <a href="index.html?cat=Tech">Tech</a>
-      <hr>
-      <a href="about.html">About</a>
-      <a href="privacy.html">Privacy</a>
-    </div>
-  </div>
 </header>
+<div class="mobile-nav" aria-hidden="true" role="dialog" aria-label="Mobile menu">
+  <div class="sheet">
+    <button class="close js-close" aria-label="Close menu">✕</button>
+    <h3>Browse deals</h3>
+    <a href="index.html">Featured</a>
+    <a href="index.html?cat=Travel">Travel</a>
+    <a href="index.html?cat=Fashion">Fashion</a>
+    <a href="index.html?cat=Marketplace">Marketplace</a>
+    <a href="index.html?cat=Automotive">Automotive</a>
+    <a href="index.html?cat=Health">Health</a>
+    <a href="index.html?cat=Tech">Tech</a>
+    <hr>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+  </div>
+</div>
 
   <main class="container">
     <h1>Privacy & Disclosures</h1>
@@ -98,6 +98,6 @@
   </div>
   <div class="smallprint">&copy; 2025 SpendLess!. All rights reserved. Affiliate links may earn us a commission.</div>
 </footer>
-
+<script src="js/nav.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use relative icon paths so favicons display
- move mobile navigation out of sticky header
- add shared `nav.js` to handle burger menu

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a022d6308326880ea75abd1855be