### PR TITLE
Fix deformed mobile menu close icon

### DIFF
--- a/about.html
+++ b/about.html
@@ -43,7 +43,7 @@
 </header>
 <div class="mobile-nav" aria-hidden="true" role="dialog" aria-label="Mobile menu">
   <div class="sheet">
-    <button class="close js-close" aria-label="Close menu">✕</button>
+    <button class="close js-close" aria-label="Close menu"><span class="close-lines"></span></button>
     <h3>Browse deals</h3>
     <a href="index.html">Featured</a>
     <a href="index.html?cat=Travel">Travel</a>

--- a/article.html
+++ b/article.html
@@ -43,7 +43,7 @@
 </header>
 <div class="mobile-nav" aria-hidden="true" role="dialog" aria-label="Mobile menu">
   <div class="sheet">
-    <button class="close js-close" aria-label="Close menu">✕</button>
+    <button class="close js-close" aria-label="Close menu"><span class="close-lines"></span></button>
     <h3>Browse deals</h3>
     <a href="index.html">Featured</a>
     <a href="index.html?cat=Travel">Travel</a>

--- a/css/style.css
+++ b/css/style.css
@@ -59,7 +59,21 @@ button.burger {
 .mobile-nav.is-open { opacity:1; pointer-events:auto; }
 .mobile-nav.is-open .sheet { transform: translateX(0); }
 .mobile-nav a { display:block; padding: .9rem 1rem; border-radius: 12px; margin:.25rem 0; background: #f3f4f6; }
-.mobile-nav .close { position:absolute; right:1rem; top:1rem; background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:.5rem .6rem; }
+.mobile-nav .close {
+  position:absolute; right:1rem; top:1rem;
+  background:#fff; border:1px solid #e5e7eb; border-radius:12px;
+  width:44px; height:44px; padding:0;
+  display:grid; place-items:center;
+}
+.close-lines, .close-lines::before {
+  display:block; width:20px; height:2px; background:#111; border-radius:2px;
+}
+.close-lines {
+  position:relative; transform: rotate(45deg);
+}
+.close-lines::before {
+  content:""; position:absolute; left:0; top:0; transform: rotate(-90deg);
+}
 
 .hero { padding: 1.5rem 0 1rem; }
 .hero h1 { font-size: clamp(1.35rem, 3vw, 2rem); margin:.5rem 0; }

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 </header>
 <div class="mobile-nav" aria-hidden="true" role="dialog" aria-label="Mobile menu">
   <div class="sheet">
-    <button class="close js-close" aria-label="Close menu">✕</button>
+    <button class="close js-close" aria-label="Close menu"><span class="close-lines"></span></button>
     <h3>Browse deals</h3>
     <a href="index.html">Featured</a>
     <a href="index.html?cat=Travel">Travel</a>

--- a/privacy.html
+++ b/privacy.html
@@ -43,7 +43,7 @@
 </header>
 <div class="mobile-nav" aria-hidden="true" role="dialog" aria-label="Mobile menu">
   <div class="sheet">
-    <button class="close js-close" aria-label="Close menu">✕</button>
+    <button class="close js-close" aria-label="Close menu"><span class="close-lines"></span></button>
     <h3>Browse deals</h3>
     <a href="index.html">Featured</a>
     <a href="index.html?cat=Travel">Travel</a>


### PR DESCRIPTION
## Summary
- Replace text-based close button with CSS cross for consistent appearance
- Apply new close button markup across HTML pages
- Style close icon using pseudo-elements for uniform sizing

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a5f990b88326868fb9540794bb65