### PR TITLE
Prevent logo text underline on hover

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -28,6 +28,7 @@ header.site-header {
 }
 .header-inner { display:flex; align-items:center; justify-content:space-between; gap:.75rem; padding:.75rem 1rem;}
 .brand { display:flex; align-items:center; gap:.6rem; font-weight:800; letter-spacing:.3px; font-size:1.1rem; text-decoration:none; }
+.brand:hover { text-decoration:none; }
 .brand-logo { width: 28px; height: 28px; border-radius: 8px; box-shadow: var(--shadow); background: #fff; }
 .brand-title { position: relative; display:inline-block; }
 .brand-title::after { content:""; position:absolute; left:0; right:0; bottom:-2px; height:2px; background:#111; transform:scaleX(0); transform-origin:left; transition: transform .25s ease; }


### PR DESCRIPTION
## Summary
- keep the brand logo hover animation while preventing browser underline styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a9a3ea4883269a062465f9258ed4