### PR TITLE
Resize logo and secure promo code reveal

### DIFF
--- a/content/ebay.md
+++ b/content/ebay.md
@@ -1,4 +1,6 @@
-# eBay Sneaker & Trading Cards Codes
+# eBay Sneaker & Trading Cards Deals
 
-- LACEUP — Sneakers tiered discount.
-- ALLDECKEDOUT — Trading cards.
+- Sneakers tiered discount available.
+- Trading card promo available.
+
+See promo section below for the latest codes.

--- a/content/expedia.md
+++ b/content/expedia.md
@@ -1,3 +1,5 @@
-# Expedia Location Codes
+# Expedia Location Tips
 
-- TAYLOR: 20% off eligible prepaid hotels in select European cities.
+- 20% off eligible prepaid hotels in select European cities.
+
+Grab the full code from the promo section.

--- a/content/hotels.md
+++ b/content/hotels.md
@@ -1,7 +1,9 @@
-# Hotels.com Codes
+# Hotels.com Tips
 
 Check exclusions on prepaid vs pay-at-hotel rates.
 
-- CARDHT8: General discount code.
-- chz: 10% off London hotels.
-- CFHCOMAUG8: August promo.
+- General discount available.
+- 10% off London hotels.
+- August promo for additional savings.
+
+Grab the exact codes in the promo section below.

--- a/content/lulus.md
+++ b/content/lulus.md
@@ -1,3 +1,5 @@
-# Lulus Bundle Code
+# Lulus Bundle Offer
 
-- BUY2GET20 — 20% off when buying two+.
+- 20% off when buying two or more items.
+
+See promo section below for the active code.

--- a/content/shein.md
+++ b/content/shein.md
@@ -1,8 +1,10 @@
 # SHEIN Mega Thread Codes
 
-Community-reported codes updated frequently.
+Community-reported tips updated frequently.
 
-> Tip: Add two different items to your cart; some codes stack with bundles.
+> Tip: Add two different items to your cart; some offers stack with bundles.
 
-- NEWONLY30 — 30% off for first-time orders.
-- US24J2 — Tiered discount based on cart total.
+- 30% off for first-time orders.
+- Tiered discount based on cart total.
+
+Find the latest working codes in the promo section below.

--- a/css/style.css
+++ b/css/style.css
@@ -29,7 +29,7 @@ header.site-header {
 .header-inner { display:flex; align-items:center; justify-content:space-between; gap:.75rem; padding:.75rem 1rem;}
 .brand { display:flex; align-items:center; gap:.6rem; font-weight:800; letter-spacing:.3px; font-size:1.1rem; text-decoration:none; }
 .brand:hover { text-decoration:none; }
-.brand-logo { width: 28px; height: 28px; border-radius: 8px; box-shadow: var(--shadow); background: #fff; }
+.brand-logo { width: 84px; height: 84px; border-radius: 24px; box-shadow: var(--shadow); background: #fff; }
 .brand-title { position: relative; display:inline-block; }
 .brand-title::after { content:""; position:absolute; left:0; right:0; bottom:-2px; height:2px; background:#111; transform:scaleX(0); transform-origin:left; transition: transform .25s ease; }
 .brand:hover .brand-title::after { transform:scaleX(1); }
@@ -136,7 +136,7 @@ article .content h1 { margin-top: 0.5rem; }
 .promo-block { margin: 1rem 0; padding: 1rem; border:2px dashed var(--pastel-orange); border-radius: 16px; background: #fff7ed; }
 .promo-list { display:grid; grid-template-columns:1fr; gap:.75rem; }
 .promo-code { display:flex; align-items:center; justify-content:space-between; gap:.75rem; background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:.75rem .9rem; }
-.code-mask { filter: blur(5px); user-select:none; }
+.code-mask { filter: blur(5px); user-select:none; pointer-events:none; }
 .reveal-btn { border:0; padding:.6rem .8rem; border-radius:10px; background: var(--pastel-pink); box-shadow: var(--shadow); font-weight:700; }
 .reveal-btn:hover { opacity:.9; cursor:pointer; }
 

--- a/js/article.js
+++ b/js/article.js
@@ -40,13 +40,14 @@ function renderArticle(article){
   const list = qs('.promo-list');
   for(const p of (article.promoCodes || [])){
     const li = document.createElement('div');
-    const visible = p.code.slice(0, -4);
-    const masked = p.code.slice(-4);
+    const split = Math.floor(p.code.length / 2);
+    const visible = p.code.slice(0, split);
+    const hidden = p.code.slice(split);
     li.className = 'promo-code';
     li.innerHTML = `
       <div>
         <div><strong>${p.label || 'Code'}</strong> – <span class="store">${p.store || ''}</span></div>
-        <div><span class="visible">${visible}</span><span class="code-mask">${masked}</span></div>
+        <div><span class="visible">${visible}</span><span class="code-mask" data-hidden="${hidden}">${'•'.repeat(hidden.length)}</span></div>
       </div>
       <button class="reveal-btn" data-url="${p.affiliateUrl}" aria-label="Reveal code and open deal">Reveal</button>
     `;
@@ -54,8 +55,11 @@ function renderArticle(article){
   }
   qsa('.reveal-btn').forEach(btn => {
     btn.addEventListener('click', (e)=>{
-      const codeEl = e.target.closest('.promo-code').querySelector('.code-mask');
-      codeEl.classList.remove('code-mask');
+      const promo = e.target.closest('.promo-code');
+      const codeWrap = promo.querySelector('.visible').parentElement;
+      const mask = promo.querySelector('.code-mask');
+      const full = promo.querySelector('.visible').textContent + mask.dataset.hidden;
+      codeWrap.textContent = full;
       const url = e.target.getAttribute('data-url');
       const w = window.open(url, '_blank', 'noopener');
       if(!w){ setTimeout(()=>{ location.href = url; }, 500); }


### PR DESCRIPTION
## Summary
- triple site logo dimensions for greater visibility
- blur exactly half of promo codes with placeholder and reveal full code while opening affiliate link in new tab
- strip promo codes from article bodies so codes only appear in dedicated promo section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ae5ce4e08326a908396c566d2ef6