### PR TITLE
Avoid redirect after revealing promo codes

### DIFF
--- a/js/article.js
+++ b/js/article.js
@@ -61,8 +61,7 @@ function renderArticle(article){
       const full = promo.querySelector('.visible').textContent + mask.dataset.hidden;
       codeWrap.textContent = full;
       const url = e.target.getAttribute('data-url');
-      const w = window.open(url, '_blank', 'noopener');
-      if(!w){ setTimeout(()=>{ location.href = url; }, 500); }
+      window.open(url, '_blank', 'noopener');
     });
   });
 }


### PR DESCRIPTION
## Summary
- Stop redirecting current page when clicking reveal; open affiliate link only in a new tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b32c4c648326be35bd8b2dae8114