### PR TITLE
Add Google Analytics gtag snippet to default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,6 +24,16 @@
     <meta name="twitter:description" content="{{ meta_description }}">
     <meta name="twitter:image" content="{{ '/media/twitter-card-1200x675.png' | absolute_url }}">
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VDFQXS74CQ"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VDFQXS74CQ');
+    </script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
       :root {


### PR DESCRIPTION
### Motivation
- Ensure Google Analytics (gtag) is initialized site-wide so pageviews and events are recorded across pages that use the `default` layout.

### Description
- Inserted the provided Google tag snippet (loads `https://www.googletagmanager.com/gtag/js?id=G-VDFQXS74CQ` and calls `gtag('config', 'G-VDFQXS74CQ')`) into `_layouts/default.html` inside the `<head>` so it runs on all pages using the shared layout.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c920e62fa08326bfd2521b21ae8010)