### PR TITLE
Fix Kiwi logo, remove XP minigame, and extend coupon reveal message

### DIFF
--- a/_brands/kiwi_com.md
+++ b/_brands/kiwi_com.md
@@ -2,7 +2,7 @@
 layout: brand
 title: "Kiwi.com discount codes"
 brand_slug: "kiwi_com"
-logo_path: "/media/brand_logos/kiwi.jpg"
+logo_path: "/media/brand_logos/kiwic.jpg"
 description_short: "Latest Kiwi.com discount codes and promo codes from /r/SpendLess."
 ---
 

--- a/_layouts/coupon.html
+++ b/_layouts/coupon.html
@@ -35,7 +35,7 @@ layout: default
         </div>
         <button type="button" data-copy-code-button data-copy-code="{{ page.code }}" data-brand-slug="{{ page.brand_slug }}" data-url-external="{{ page.url_external }}" class="rounded-xl border border-slate-700 bg-slate-800 px-4 py-2 text-sm font-semibold">View Code</button>
       </div>
-      <p id="copy-message" class="text-xs text-emerald-300 opacity-0 transition-opacity mt-2">Code activated &amp; Copied to clipbord</p>
+      <p id="copy-message" class="text-xs text-emerald-300 opacity-0 transition-opacity mt-2">Code copied &amp; Active!</p>
     </section>
   {% endif %}
 
@@ -47,8 +47,6 @@ layout: default
         const button = document.querySelector('[data-copy-code-button]');
         const display = document.querySelector('[data-code-display]');
         const status = document.getElementById('copy-message');
-        const couponId = {{ page.url | relative_url | jsonify }};
-        const xpStorageKey = 'spendless-xp-unlocked-coupons';
         if (!button || !display) return;
 
         const code = button.dataset.copyCode;
@@ -95,15 +93,8 @@ layout: default
           display.classList.remove('code-fluid-blur', 'select-none');
           display.classList.add('is-revealed');
           navigator.clipboard?.writeText(code).catch(() => {});
-          let unlocked = [];
-          try { unlocked = JSON.parse(localStorage.getItem(xpStorageKey) || "[]"); } catch (_) { unlocked = []; }
-          if (!unlocked.includes(couponId)) {
-            unlocked.push(couponId);
-            localStorage.setItem(xpStorageKey, JSON.stringify(unlocked));
-            if (window.updateScore) window.updateScore(5);
-          }
           status.style.opacity = '1';
-          setTimeout(() => status.style.opacity = '0', 2500);
+          setTimeout(() => status.style.opacity = '0', 10000);
         });
       });
     </script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -104,45 +104,6 @@
         transform: translateY(-2px) scale(1.01);
       }
 
-      .xp-shell {
-        position: relative;
-        overflow: hidden;
-      }
-
-      .xp-shell::after {
-        content: '';
-        position: absolute;
-        inset: 0;
-        background: linear-gradient(120deg, transparent 25%, rgba(255, 255, 255, 0.35) 50%, transparent 75%);
-        transform: translateX(-120%);
-        pointer-events: none;
-      }
-
-      .xp-shell.xp-animate::after {
-        animation: xpShine 2.6s ease-in-out 1;
-      }
-
-      #xp-progress {
-        transition: width .45s ease;
-        position: relative;
-      }
-
-      .xp-shell.xp-animate #xp-progress {
-        animation: xpPulse 1.8s ease-in-out 1;
-      }
-
-      #xp-progress::after {
-        content: '';
-        position: absolute;
-        inset: 0;
-        background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.45) 50%, transparent 100%);
-        transform: translateX(-100%);
-      }
-
-      .xp-shell.xp-animate #xp-progress::after {
-        animation: xpSweep 2.2s linear 1;
-      }
-
       .code-fluid-blur {
         display: inline-block;
         filter: blur(5.6px) contrast(1.1);
@@ -154,21 +115,6 @@
       .code-fluid-blur.is-revealed {
         filter: none;
         animation: none;
-      }
-
-      @keyframes xpShine {
-        0%, 85%, 100% { transform: translateX(-120%); }
-        45% { transform: translateX(120%); }
-      }
-
-      @keyframes xpPulse {
-        0%, 100% { box-shadow: 0 0 0 rgba(59, 130, 246, 0.35); }
-        50% { box-shadow: 0 0 14px rgba(59, 130, 246, 0.75); }
-      }
-
-      @keyframes xpSweep {
-        0% { transform: translateX(-100%); }
-        100% { transform: translateX(100%); }
       }
 
       @keyframes fluidBlur {
@@ -213,18 +159,6 @@
             </span>
           </a>
           <nav class="relative text-xs flex items-center gap-1.5 sm:gap-2 shrink-0">
-            <button id="xp-panel" type="button" class="xp-shell rounded-xl px-2 py-1 liquid-glass w-[124px] sm:w-[156px] text-left" aria-describedby="xp-tooltip" aria-label="XP progress. Collect more offers to unlock exclusive deals">
-              <div class="flex items-center justify-between gap-2 text-[11px] font-semibold">
-                <span id="scoreboard">XP 0</span>
-                <span id="levelboard" class="text-slate-500">Lv. 1</span>
-              </div>
-              <div class="mt-1 h-1.5 rounded-full bg-slate-300/50 overflow-hidden">
-                <div id="xp-progress" class="h-full bg-blue-500/80" style="width:0%"></div>
-              </div>
-            </button>
-            <div id="xp-tooltip" role="tooltip" class="hidden absolute right-8 top-[72px] sm:top-[80px] w-[260px] rounded-xl border border-sky-300/40 bg-gradient-to-br from-slate-900 via-slate-800 to-sky-900 text-slate-100 px-3 py-2 text-xs shadow-2xl z-30">
-              Collect more offers to unlock exclusive deals
-            </div>
             <button id="theme-toggle" type="button" aria-label="Toggle dark mode" class="rounded-full border w-10 h-10 flex items-center justify-center text-lg font-semibold liquid-glass">
               <span id="theme-toggle-icon" aria-hidden="true"></span>
             </button>
@@ -250,9 +184,6 @@
         const toggleButton = document.getElementById('theme-toggle');
         const toggleIcon = document.getElementById('theme-toggle-icon');
         const storageKey = 'spendless-theme';
-        const scoreEl = document.getElementById('scoreboard');
-        const levelEl = document.getElementById('levelboard');
-        const progressEl = document.getElementById('xp-progress');
 
         const storedTheme = localStorage.getItem(storageKey);
         applyTheme(storedTheme || 'light');
@@ -271,55 +202,6 @@
               ? '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2"></path><path d="M12 20v2"></path><path d="m4.93 4.93 1.41 1.41"></path><path d="m17.66 17.66 1.41 1.41"></path><path d="M2 12h2"></path><path d="M20 12h2"></path><path d="m6.34 17.66-1.41 1.41"></path><path d="m19.07 4.93-1.41 1.41"></path></svg>'
               : '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a7 7 0 1 0 9 9 9 9 0 1 1-9-9z"></path></svg>';
           }
-        }
-
-        function renderScore() {
-          const score = parseInt(localStorage.getItem('sl_score') || '0', 10);
-          const level = Math.floor(score / 100) + 1;
-          const progress = score % 100;
-          if (scoreEl) scoreEl.textContent = `XP ${score}`;
-          if (levelEl) levelEl.textContent = `Lv. ${level}`;
-          if (progressEl) progressEl.style.width = `${progress}%`;
-        }
-
-        window.updateScore = function (amount) {
-          const next = parseInt(localStorage.getItem('sl_score') || '0', 10) + (amount || 1);
-          localStorage.setItem('sl_score', next);
-          renderScore();
-        };
-
-        renderScore();
-
-        const xpPanel = document.getElementById('xp-panel');
-        const xpTooltip = document.getElementById('xp-tooltip');
-        const xpMessage = 'Collect more offers to unlock exclusive deals';
-        if (xpPanel && xpTooltip) {
-          xpPanel.title = xpMessage;
-          const announce = () => {
-            xpPanel.setAttribute('aria-label', `XP progress. ${xpMessage}`);
-            xpTooltip.classList.remove('hidden');
-          };
-          const hide = () => xpTooltip.classList.add('hidden');
-          xpPanel.addEventListener('mouseenter', announce);
-          xpPanel.addEventListener('mouseleave', hide);
-          xpPanel.addEventListener('focus', announce);
-          xpPanel.addEventListener('blur', hide);
-          xpPanel.addEventListener('click', announce);
-          xpPanel.addEventListener('touchstart', announce, { passive: true });
-          xpPanel.addEventListener('touchend', () => setTimeout(hide, 1200), { passive: true });
-        }
-
-
-        if (xpPanel) {
-          const triggerXpAnimation = () => {
-            xpPanel.classList.remove('xp-animate');
-            void xpPanel.offsetWidth;
-            xpPanel.classList.add('xp-animate');
-            window.setTimeout(() => xpPanel.classList.remove('xp-animate'), 2700);
-          };
-
-          triggerXpAnimation();
-          window.setInterval(triggerXpAnimation, 10000);
         }
 
         if ('startViewTransition' in document && window.matchMedia('(max-width: 640px)').matches) {


### PR DESCRIPTION
### Motivation

- The Kiwi.com brand logo asset was referenced incorrectly which prevented the logo from rendering. 
- The XP "minigame" UI and related client-side tracking added visual clutter and unused state, so it was removed. 
- Coupon reveal UX needed a clearer message and a longer visibility period after clicking `View Code`.

### Description

- Updated `_brands/kiwi_com.md` to use the existing logo asset by changing `logo_path` to `/media/brand_logos/kiwic.jpg` so the Kiwi logo displays. 
- Removed XP-related CSS, header XP panel/tooltip markup, and all XP score/tracking/animation JavaScript from `_layouts/default.html` to eliminate the XP minigame UI and behavior. 
- Updated `_layouts/coupon.html` to change the reveal message to `Code copied & Active!`, removed the XP unlock/localStorage unlock logic, and extended the reveal message timeout from `2500`ms to `10000`ms.

### Testing

- Ran `git diff --check` with no issues reported. 
- Attempted `bundle exec jekyll build --quiet` but the build could not be executed in this environment because there is no `Gemfile`/Bundler setup, so a full site build was not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1bb12fc48326a07ccc7d48fb299f)