### PR TITLE
Add missing PlayStation and Saily coupon markdown files

### DIFF
--- a/_coupons/playstation/ation15-15-off-digital-games.md
+++ b/_coupons/playstation/ation15-15-off-digital-games.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "15% off PlayStation digital games"
+brand_slug: playstation
+discount_value: 15% off
+code: ATION15
+is_expired: false
+description_short: 15% off PlayStation digital games
+---
+Use code ATION15 at checkout to get 15% off on PlayStation digital games.

--- a/_coupons/playstation/ctik-10-off-digital-games.md
+++ b/_coupons/playstation/ctik-10-off-digital-games.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "10% off PlayStation digital games"
+brand_slug: playstation
+discount_value: 10% off
+code: CTIK
+is_expired: false
+description_short: 10% off PlayStation digital games
+---
+Use code CTIK at checkout to get 10% off on PlayStation digital games.

--- a/_coupons/playstation/daysofplay20-20-off-purchase.md
+++ b/_coupons/playstation/daysofplay20-20-off-purchase.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "20% off PlayStation purchase"
+brand_slug: playstation
+discount_value: 20% off
+code: DAYSOFPLAY20
+is_expired: false
+description_short: 20% off PlayStation purchase
+---
+Use code DAYSOFPLAY20 at checkout to get 20% off on your PlayStation purchase.

--- a/_coupons/playstation/daysofplay22-20-off-purchase.md
+++ b/_coupons/playstation/daysofplay22-20-off-purchase.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "20% off PlayStation purchase"
+brand_slug: playstation
+discount_value: 20% off
+code: DAYSOFPLAY22
+is_expired: false
+description_short: 20% off PlayStation purchase
+---
+Use code DAYSOFPLAY22 at checkout to get 20% off on your PlayStation purchase.

--- a/_coupons/playstation/daysofplay24-20-off-purchase.md
+++ b/_coupons/playstation/daysofplay24-20-off-purchase.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "20% off PlayStation purchase"
+brand_slug: playstation
+discount_value: 20% off
+code: DAYSOFPLAY24
+is_expired: false
+description_short: 20% off PlayStation purchase
+---
+Use code DAYSOFPLAY24 at checkout to get 20% off on your PlayStation purchase.

--- a/_coupons/playstation/daysofplay25-25-off-purchase.md
+++ b/_coupons/playstation/daysofplay25-25-off-purchase.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "25% off PlayStation purchase"
+brand_slug: playstation
+discount_value: 25% off
+code: DAYSOFPLAY25
+is_expired: false
+description_short: 25% off PlayStation purchase
+---
+Use code DAYSOFPLAY25 at checkout to get 25% off on your PlayStation purchase.

--- a/_coupons/playstation/daysofplay26-20-off-purchase.md
+++ b/_coupons/playstation/daysofplay26-20-off-purchase.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "20% off PlayStation purchase"
+brand_slug: playstation
+discount_value: 20% off
+code: DAYSOFPLAY26
+is_expired: false
+description_short: 20% off PlayStation purchase
+---
+Use code DAYSOFPLAY26 at checkout to get 20% off on your PlayStation purchase.

--- a/_coupons/playstation/evo2025-15-off-purchase.md
+++ b/_coupons/playstation/evo2025-15-off-purchase.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "15% off PlayStation purchase"
+brand_slug: playstation
+discount_value: 15% off
+code: EVO2025
+is_expired: false
+description_short: 15% off PlayStation purchase
+---
+Use code EVO2025 at checkout to get 15% off on your PlayStation purchase.

--- a/_coupons/playstation/extra75-75-off-playstation-plus-membership.md
+++ b/_coupons/playstation/extra75-75-off-playstation-plus-membership.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "75% off PlayStation Plus membership"
+brand_slug: playstation
+discount_value: 75% off membership
+code: EXTRA75
+is_expired: false
+description_short: 75% off PlayStation Plus membership
+---
+Use code EXTRA75 at checkout to get 75% off membership on eligible PlayStation Plus memberships (for eligible memberships).

--- a/_coupons/playstation/h9jdfd57mn-40-off-purchase.md
+++ b/_coupons/playstation/h9jdfd57mn-40-off-purchase.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "40% off PlayStation purchase"
+brand_slug: playstation
+discount_value: 40% off
+code: H9JDFD57MN
+is_expired: false
+description_short: 40% off PlayStation purchase
+---
+Use code H9JDFD57MN at checkout to get 40% off on your PlayStation purchase.

--- a/_coupons/playstation/midyearsale-20-off-purchase.md
+++ b/_coupons/playstation/midyearsale-20-off-purchase.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "20% off PlayStation purchase"
+brand_slug: playstation
+discount_value: 20% off
+code: MIDYEARSALE
+is_expired: false
+description_short: 20% off PlayStation purchase
+---
+Use code MIDYEARSALE at checkout to get 20% off on your PlayStation purchase.

--- a/_coupons/playstation/playstation15-15-off-purchase.md
+++ b/_coupons/playstation/playstation15-15-off-purchase.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "15% off PlayStation purchase"
+brand_slug: playstation
+discount_value: 15% off
+code: PLAYSTATION15
+is_expired: false
+description_short: 15% off PlayStation purchase
+---
+Use code PLAYSTATION15 at checkout to get 15% off on your PlayStation purchase.

--- a/_coupons/playstation/sackboy10-10-off-purchase.md
+++ b/_coupons/playstation/sackboy10-10-off-purchase.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "10% off PlayStation purchase"
+brand_slug: playstation
+discount_value: 10% off
+code: SACKBOY10
+is_expired: false
+description_short: 10% off PlayStation purchase
+---
+Use code SACKBOY10 at checkout to get 10% off on your PlayStation purchase.

--- a/_coupons/playstation/weekendsave-10-off-saturday-purchases.md
+++ b/_coupons/playstation/weekendsave-10-off-saturday-purchases.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "10% off PlayStation purchase"
+brand_slug: playstation
+discount_value: 10% off
+code: WEEKENDSAVE
+is_expired: false
+description_short: 10% off PlayStation purchases on Saturdays only
+---
+Use code WEEKENDSAVE at checkout to get 10% off on your PlayStation purchase (valid on Saturdays only).

--- a/_coupons/saily/anthon2776-5-off-plans.md
+++ b/_coupons/saily/anthon2776-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$5 off Saily plans"
+brand_slug: saily
+discount_value: $5 off
+code: ANTHON2776
+is_expired: false
+description_short: $5 off Saily plans
+---
+Use code ANTHON2776 at checkout to get $5 off on your Saily plan.

--- a/_coupons/saily/arneeh1157-8-off-plans.md
+++ b/_coupons/saily/arneeh1157-8-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$8 off Saily plans"
+brand_slug: saily
+discount_value: $8 off
+code: ARNEEH1157
+is_expired: false
+description_short: $8 off Saily plans
+---
+Use code ARNEEH1157 at checkout to get $8 off on your Saily plan.

--- a/_coupons/saily/benori8447-8-off-plans.md
+++ b/_coupons/saily/benori8447-8-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$8 off Saily plans"
+brand_slug: saily
+discount_value: $8 off
+code: BENORI8447
+is_expired: false
+description_short: $8 off Saily plans
+---
+Use code BENORI8447 at checkout to get $8 off on your Saily plan.

--- a/_coupons/saily/cadenr1029-up-to-8-off-plans.md
+++ b/_coupons/saily/cadenr1029-up-to-8-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "Up to $8 off Saily plans"
+brand_slug: saily
+discount_value: Up to $8 off
+code: CADENR1029
+is_expired: false
+description_short: Up to $8 off Saily plans
+---
+Use code CADENR1029 at checkout to get up to $8 off on your Saily plan (discount varies by plan).

--- a/_coupons/saily/carter9459-up-to-10-off-plans.md
+++ b/_coupons/saily/carter9459-up-to-10-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "Up to $10 off Saily plans"
+brand_slug: saily
+discount_value: Up to $10 off
+code: CARTER9459
+is_expired: false
+description_short: Up to $10 off Saily plans
+---
+Use code CARTER9459 at checkout to get up to $10 off on your Saily plan (discount varies by plan).

--- a/_coupons/saily/ceeret2177-8-off-plans.md
+++ b/_coupons/saily/ceeret2177-8-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$8 off Saily plans"
+brand_slug: saily
+discount_value: $8 off
+code: CEERET2177
+is_expired: false
+description_short: $8 off Saily plans
+---
+Use code CEERET2177 at checkout to get $8 off on your Saily plan.

--- a/_coupons/saily/chanta5278-5-off-plans.md
+++ b/_coupons/saily/chanta5278-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$5 off Saily plans"
+brand_slug: saily
+discount_value: $5 off
+code: CHANTA5278
+is_expired: false
+description_short: $5 off Saily plans
+---
+Use code CHANTA5278 at checkout to get $5 off on your Saily plan.

--- a/_coupons/saily/cnews5-10-off-plans.md
+++ b/_coupons/saily/cnews5-10-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "10% off Saily plans"
+brand_slug: saily
+discount_value: 10% off
+code: CNEWS5
+is_expired: false
+description_short: 10% off Saily plans
+---
+Use code CNEWS5 at checkout to get 10% off on your Saily plan.

--- a/_coupons/saily/deal15-15-off-plans.md
+++ b/_coupons/saily/deal15-15-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "15% off Saily plans"
+brand_slug: saily
+discount_value: 15% off
+code: deal15
+is_expired: false
+description_short: 15% off Saily plans
+---
+Use code deal15 at checkout to get 15% off on your Saily plan.

--- a/_coupons/saily/deal5-5-off-plans.md
+++ b/_coupons/saily/deal5-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "5% off Saily plans"
+brand_slug: saily
+discount_value: 5% off
+code: DEAL5
+is_expired: false
+description_short: 5% off Saily plans
+---
+Use code DEAL5 at checkout to get 5% off on your Saily plan.

--- a/_coupons/saily/demand5-5-off-new-customers.md
+++ b/_coupons/saily/demand5-5-off-new-customers.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "5% off for new Saily customers"
+brand_slug: saily
+discount_value: 5% off
+code: DEMAND5
+is_expired: false
+description_short: 5% off for new customers
+---
+Use code DEMAND5 at checkout to get 5% off on your Saily plan (new customers only).

--- a/_coupons/saily/dpf5-5-off-first-purchase.md
+++ b/_coupons/saily/dpf5-5-off-first-purchase.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "5% off first Saily purchase"
+brand_slug: saily
+discount_value: 5% off
+code: DPF5
+is_expired: false
+description_short: 5% off first Saily purchase
+---
+Use code DPF5 at checkout to get 5% off on your Saily plan (first purchase only).

--- a/_coupons/saily/gap15-15-off-orders.md
+++ b/_coupons/saily/gap15-15-off-orders.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "15% off Saily orders"
+brand_slug: saily
+discount_value: 15% off
+code: GAP15
+is_expired: false
+description_short: 15% off Saily orders
+---
+Use code GAP15 at checkout to get 15% off on your Saily order.

--- a/_coupons/saily/grizzl7060-5-off-plans.md
+++ b/_coupons/saily/grizzl7060-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$5 off Saily plans"
+brand_slug: saily
+discount_value: $5 off
+code: GRIZZL7060
+is_expired: false
+description_short: $5 off Saily plans
+---
+Use code GRIZZL7060 at checkout to get $5 off on your Saily plan.

--- a/_coupons/saily/hellosaily-10-off-plans.md
+++ b/_coupons/saily/hellosaily-10-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "10% off Saily plans"
+brand_slug: saily
+discount_value: 10% off
+code: hellosaily
+is_expired: false
+description_short: 10% off Saily plans
+---
+Use code hellosaily at checkout to get 10% off on your Saily plan.

--- a/_coupons/saily/hellosaily-15-off-plans.md
+++ b/_coupons/saily/hellosaily-15-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "15% off Saily plans"
+brand_slug: saily
+discount_value: 15% off
+code: HELLOSAILY
+is_expired: false
+description_short: 15% off Saily plans
+---
+Use code HELLOSAILY at checkout to get 15% off on your Saily plan.

--- a/_coupons/saily/hugowe7868-5-off-plans.md
+++ b/_coupons/saily/hugowe7868-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$5 off Saily plans"
+brand_slug: saily
+discount_value: $5 off
+code: HUGOWE7868
+is_expired: false
+description_short: $5 off Saily plans
+---
+Use code HUGOWE7868 at checkout to get $5 off on your Saily plan.

--- a/_coupons/saily/ismare7776-3-off-plans.md
+++ b/_coupons/saily/ismare7776-3-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$3 off Saily plans"
+brand_slug: saily
+discount_value: $3 off
+code: ISMARE7776
+is_expired: false
+description_short: $3 off Saily plans
+---
+Use code ISMARE7776 at checkout to get $3 off on your Saily plan.

--- a/_coupons/saily/jen15-15-off-plans.md
+++ b/_coupons/saily/jen15-15-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "15% off Saily plans"
+brand_slug: saily
+discount_value: 15% off
+code: JEN15
+is_expired: false
+description_short: 15% off Saily plans
+---
+Use code JEN15 at checkout to get 15% off on your Saily plan.

--- a/_coupons/saily/jonath3770-8-off-plans.md
+++ b/_coupons/saily/jonath3770-8-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$8 off Saily plans"
+brand_slug: saily
+discount_value: $8 off
+code: JONATH3770
+is_expired: false
+description_short: $8 off Saily plans
+---
+Use code JONATH3770 at checkout to get $8 off on your Saily plan.

--- a/_coupons/saily/joshrimer-about-15-off-plans.md
+++ b/_coupons/saily/joshrimer-about-15-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "About 15% off Saily plans"
+brand_slug: saily
+discount_value: About 15% off
+code: JOSHRIMER
+is_expired: false
+description_short: About 15% off Saily plans
+---
+Use code JOSHRIMER at checkout to get about 15% off on your Saily plan (discount may vary).

--- a/_coupons/saily/joshse4561-5-off-plans.md
+++ b/_coupons/saily/joshse4561-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$5 off Saily plans"
+brand_slug: saily
+discount_value: $5 off
+code: JOSHSE4561
+is_expired: false
+description_short: $5 off Saily plans
+---
+Use code JOSHSE4561 at checkout to get $5 off on your Saily plan.

--- a/_coupons/saily/kaylee1438-5-off-plans.md
+++ b/_coupons/saily/kaylee1438-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$5 off Saily plans"
+brand_slug: saily
+discount_value: $5 off
+code: KAYLEE1438
+is_expired: false
+description_short: $5 off Saily plans
+---
+Use code KAYLEE1438 at checkout to get $5 off on your Saily plan.

--- a/_coupons/saily/kesilo6455-3-off-plans.md
+++ b/_coupons/saily/kesilo6455-3-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$3 off Saily plans"
+brand_slug: saily
+discount_value: $3 off
+code: KESILO6455
+is_expired: false
+description_short: $3 off Saily plans
+---
+Use code KESILO6455 at checkout to get $3 off on your Saily plan.

--- a/_coupons/saily/leejeam15-15-off-plans.md
+++ b/_coupons/saily/leejeam15-15-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "15% off Saily plans"
+brand_slug: saily
+discount_value: 15% off
+code: LEEJEAM15
+is_expired: false
+description_short: 15% off Saily plans
+---
+Use code LEEJEAM15 at checkout to get 15% off on your Saily plan.

--- a/_coupons/saily/monali1964-5-off-plans.md
+++ b/_coupons/saily/monali1964-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$5 off Saily plans"
+brand_slug: saily
+discount_value: $5 off
+code: MONALI1964
+is_expired: false
+description_short: $5 off Saily plans
+---
+Use code MONALI1964 at checkout to get $5 off on your Saily plan.

--- a/_coupons/saily/n2714-5-off-plans.md
+++ b/_coupons/saily/n2714-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$5 off Saily plans"
+brand_slug: saily
+discount_value: $5 off
+code: N2714
+is_expired: false
+description_short: $5 off Saily plans
+---
+Use code N2714 at checkout to get $5 off on your Saily plan.

--- a/_coupons/saily/parthb8062-8-off-plans.md
+++ b/_coupons/saily/parthb8062-8-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$8 off Saily plans"
+brand_slug: saily
+discount_value: $8 off
+code: PARTHB8062
+is_expired: false
+description_short: $8 off Saily plans
+---
+Use code PARTHB8062 at checkout to get $8 off on your Saily plan.

--- a/_coupons/saily/petitestyleb-5-off-plans.md
+++ b/_coupons/saily/petitestyleb-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "5% off Saily plans"
+brand_slug: saily
+discount_value: 5% off
+code: PETITESTYLEB
+is_expired: false
+description_short: 5% off Saily plans
+---
+Use code PETITESTYLEB at checkout to get 5% off on your Saily plan.

--- a/_coupons/saily/riccar1760-8-off-plans.md
+++ b/_coupons/saily/riccar1760-8-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$8 off Saily plans"
+brand_slug: saily
+discount_value: $8 off
+code: RICCAR1760
+is_expired: false
+description_short: $8 off Saily plans
+---
+Use code RICCAR1760 at checkout to get $8 off on your Saily plan.

--- a/_coupons/saily/saily10-10-off-plans.md
+++ b/_coupons/saily/saily10-10-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "10% off Saily plans"
+brand_slug: saily
+discount_value: 10% off
+code: SAILY10
+is_expired: false
+description_short: 10% off Saily plans
+---
+Use code SAILY10 at checkout to get 10% off on your Saily plan.

--- a/_coupons/saily/saily5-5-off-any-plan.md
+++ b/_coupons/saily/saily5-5-off-any-plan.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "5% off any Saily plan"
+brand_slug: saily
+discount_value: 5% off
+code: SAILY5
+is_expired: false
+description_short: 5% off any Saily plan
+---
+Use code SAILY5 at checkout to get 5% off on your Saily plan.

--- a/_coupons/saily/sailyactive-15-off-plans.md
+++ b/_coupons/saily/sailyactive-15-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "15% off Saily plans"
+brand_slug: saily
+discount_value: 15% off
+code: sailyactive
+is_expired: false
+description_short: 15% off Saily plans
+---
+Use code sailyactive at checkout to get 15% off on your Saily plan.

--- a/_coupons/saily/sailyreddit-15-off-plans.md
+++ b/_coupons/saily/sailyreddit-15-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "15% off Saily plans"
+brand_slug: saily
+discount_value: 15% off
+code: Sailyreddit
+is_expired: false
+description_short: 15% off Saily plans
+---
+Use code Sailyreddit at checkout to get 15% off on your Saily plan.

--- a/_coupons/saily/samirw8757-8-off-plans.md
+++ b/_coupons/saily/samirw8757-8-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$8 off Saily plans"
+brand_slug: saily
+discount_value: $8 off
+code: SAMIRW8757
+is_expired: false
+description_short: $8 off Saily plans
+---
+Use code SAMIRW8757 at checkout to get $8 off on your Saily plan.

--- a/_coupons/saily/sarahc8720-8-off-plans.md
+++ b/_coupons/saily/sarahc8720-8-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$8 off Saily plans"
+brand_slug: saily
+discount_value: $8 off
+code: SARAHC8720
+is_expired: false
+description_short: $8 off Saily plans
+---
+Use code SARAHC8720 at checkout to get $8 off on your Saily plan.

--- a/_coupons/saily/shaile3175-5-off-first-plan.md
+++ b/_coupons/saily/shaile3175-5-off-first-plan.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$5 off first Saily plan"
+brand_slug: saily
+discount_value: $5 off
+code: SHAILE3175
+is_expired: false
+description_short: $5 off first Saily plan
+---
+Use code SHAILE3175 at checkout to get $5 off on your Saily plan (first plan only).

--- a/_coupons/saily/snow5-5-off-10gb-plans.md
+++ b/_coupons/saily/snow5-5-off-10gb-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "5% off Saily 10GB+ plans"
+brand_slug: saily
+discount_value: 5% off
+code: SNOW5
+is_expired: false
+description_short: 5% off Saily plans 10GB and above
+---
+Use code SNOW5 at checkout to get 5% off on your Saily plan (10GB+ plans only).

--- a/_coupons/saily/tee15-15-off-plans.md
+++ b/_coupons/saily/tee15-15-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "15% off Saily plans"
+brand_slug: saily
+discount_value: 15% off
+code: TEE15
+is_expired: false
+description_short: 15% off Saily plans
+---
+Use code TEE15 at checkout to get 15% off on your Saily plan.

--- a/_coupons/saily/trysaily5-5-off-first-orders.md
+++ b/_coupons/saily/trysaily5-5-off-first-orders.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "5% off first Saily orders"
+brand_slug: saily
+discount_value: 5% off
+code: TRYSAILY5
+is_expired: false
+description_short: 5% off first Saily orders
+---
+Use code TRYSAILY5 at checkout to get 5% off on your Saily order (first orders only).

--- a/_coupons/saily/umangp2180-5-off-plans.md
+++ b/_coupons/saily/umangp2180-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$5 off Saily plans"
+brand_slug: saily
+discount_value: $5 off
+code: UMANGP2180
+is_expired: false
+description_short: $5 off Saily plans
+---
+Use code UMANGP2180 at checkout to get $5 off on your Saily plan.

--- a/_coupons/saily/vasili7361-5-off-plans.md
+++ b/_coupons/saily/vasili7361-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$5 off Saily plans"
+brand_slug: saily
+discount_value: $5 off
+code: VASILI7361
+is_expired: false
+description_short: $5 off Saily plans
+---
+Use code VASILI7361 at checkout to get $5 off on your Saily plan.

--- a/_coupons/saily/vikend0703-5-off-plans.md
+++ b/_coupons/saily/vikend0703-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$5 off Saily plans"
+brand_slug: saily
+discount_value: $5 off
+code: VIKEND0703
+is_expired: false
+description_short: $5 off Saily plans
+---
+Use code VIKEND0703 at checkout to get $5 off on your Saily plan.

--- a/_coupons/saily/wateca6691-5-off-plans.md
+++ b/_coupons/saily/wateca6691-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$5 off Saily plans"
+brand_slug: saily
+discount_value: $5 off
+code: WATECA6691
+is_expired: false
+description_short: $5 off Saily plans
+---
+Use code WATECA6691 at checkout to get $5 off on your Saily plan.

--- a/_coupons/saily/y0904-5-off-plans.md
+++ b/_coupons/saily/y0904-5-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "$5 off Saily plans"
+brand_slug: saily
+discount_value: $5 off
+code: Y0904
+is_expired: false
+description_short: $5 off Saily plans
+---
+Use code Y0904 at checkout to get $5 off on your Saily plan.

--- a/_coupons/saily/zalgiris-15-off-plans.md
+++ b/_coupons/saily/zalgiris-15-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "15% off Saily plans"
+brand_slug: saily
+discount_value: 15% off
+code: ZALGIRIS
+is_expired: false
+description_short: 15% off Saily plans
+---
+Use code ZALGIRIS at checkout to get 15% off on your Saily plan.

--- a/_coupons/saily/zlotkoo-15-20-off-plans.md
+++ b/_coupons/saily/zlotkoo-15-20-off-plans.md
@@ -1,0 +1,10 @@
+---
+layout: coupon
+title: "15-20% off Saily plans"
+brand_slug: saily
+discount_value: 15-20% off
+code: ZLOTKOO
+is_expired: false
+description_short: 15-20% off Saily plans
+---
+Use code ZLOTKOO at checkout to get 15-20% off on your Saily plan (discount varies by plan).


### PR DESCRIPTION
### Motivation
- Complete the coupon dataset for the PlayStation and Saily brands by adding promo codes surfaced in the /r/SpendLess threads so the site can list currently-available community-shared discounts. 
- Ensure every coupon file adheres to the repository's front-matter schema so entries render consistently on the Jekyll site.

### Description
- Added the remaining PlayStation coupon files under `_coupons/playstation/` (new promo files such as `evo2025-15-off-purchase.md`, `weekendsave-10-off-saturday-purchases.md`, `extra75-75-off-playstation-plus-membership.md`, etc.) and used the required front matter fields (`layout`, `title`, `brand_slug`, `discount_value`, `code`, `is_expired`, `description_short`) plus a one-line usage sentence in each file. 
- Created the `_coupons/saily/` directory and added Saily coupon files for the February and March 2026 megathreads covering fixed-dollar, percent-off, and variable discounts (examples: `tee15-15-off-plans.md`, `zlotkoo-15-20-off-plans.md`, `demand5-5-off-new-customers.md`).
- Preserved case-sensitive variants when both were present in sources (for example `HELLOSAILY` and `hellosaily`) so each community-shared code appears independently. 
- Kept metadata and usage text consistent with the repository guidelines and noted scope restrictions where applicable (e.g., Saturday-only or new-customer-only promos).

### Testing
- Ran a Python schema-presence check across the new files under `_coupons/playstation/` and `_coupons/saily/`, which reported no missing required front-matter fields. 
- Verified the repository changes produced the expected additions: a total of 61 files were added across the change set with 610 lines inserted. 
- Inspected a sample of created files (for example `evo2025-15-off-purchase.md`, `weekendsave-10-off-saturday-purchases.md`, and `tee15-15-off-plans.md`) to confirm the front matter and one-line usage body render as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea53d95c608326b3899681ea28e9db)